### PR TITLE
Fixing typo in handling response

### DIFF
--- a/password_reset.html
+++ b/password_reset.html
@@ -62,8 +62,8 @@
 
       var handleSuccess = function(res) {
         // Check if the Email Template contains a redirectTo url.  If so redirect there.
-        if (res.body && typeof res.body.result_url === "string") {
-          return window.location.replace(res.body.result_url);
+        if (res && typeof res.result_url === "string") {
+          return window.location.replace(res.result_url);
         } else {
           // Show and on-page view
           resetView.hide();


### PR DESCRIPTION
Tried this and found it does not redirect to the `result_url`. 
Turns out there was an unnecessary check for a `body` nested in the response object which doesn't exist. This PR fixes that. 